### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
 	"perl" : "6.*",
 	"name" : "LendingClub",
+	"license" : "Artistic-2.0",
 	"version" : "0.1.0",
 	"description" : "A wrapper for the Lending Club API.",
 	"authors" : [ "James (Jeremy) Carman <developer@peelle.org>" ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license